### PR TITLE
Линия редеет по мере удаления шариков

### DIFF
--- a/particle.js
+++ b/particle.js
@@ -62,7 +62,13 @@
 				length = Math.sqrt(Math.pow(x2 - x1,2) + Math.pow(y2 - y1,2))
 				if(length < properties.lineLength)
 				{
-					ctx.lineWidth = "0,5";
+					if(length < properties.lineLength)
+				{
+					if (100000/(length*length*length) > 1){
+						ctx.lineWidth = 1;
+					}else{
+					ctx.lineWidth = 100000/(length*length*length);
+				}
 					ctx.strokeStyle ='rgba(255,40,40,1)';
 					ctx.beginPath();
 					ctx.moveTo(x1,y1);


### PR DESCRIPTION
Чтобы сделать эффект "редения" или "прозрачности" задал ширине линии значение 100000/(length x length x length) , означающее что, чем меньше длина, тем больше ширина, (можно было просто 100/length, но чем больше length в знаменателе, тем динамичнее и плавнее меняется ширина линии). Так же добавил, что если если значение ширины будет больше 1 (100000/(length x length x length) > 1) , то ширина равна 1, это условие было создано, из-за того, что когда шарики находились в плотную, то их ширина линии становилась настолько огромной, что происходили некрасивые графические дефекты.